### PR TITLE
Fix app insights dependency for bicep and use non buffering logger

### DIFF
--- a/bicep/apim/apimLogger.bicep
+++ b/bicep/apim/apimLogger.bicep
@@ -35,5 +35,6 @@ resource apimLogger 'Microsoft.ApiManagement/service/loggers@2023-03-01-preview'
       connectionString: eventHubNamespaceConnectionString
       name: eventHubNamespace.name
     }
+     isBuffered: false
   }
 }

--- a/bicep/monitoring/applicationInsights.bicep
+++ b/bicep/monitoring/applicationInsights.bicep
@@ -68,6 +68,9 @@ module privateEndpoint '../network/privateEndpoint.bicep' = {
     vnetName: vnetName
     location: location
   }
+  dependsOn: [
+    applicationInsights
+  ]
 }
 
 resource appInsightsScopedResource 'Microsoft.Insights/privateLinkScopes/scopedResources@2021-07-01-preview' = {
@@ -76,4 +79,7 @@ resource appInsightsScopedResource 'Microsoft.Insights/privateLinkScopes/scopedR
   properties: {
     linkedResourceId: applicationInsights.id
   }
+  dependsOn: [
+    privateEndpoint
+  ]
 }


### PR DESCRIPTION
Fix following issues

- Application Insight deployment failed due to insufficient dependency in bicep
- We should use non-buffering logger 